### PR TITLE
libril: Fix rild crash for dial.

### DIFF
--- a/include/telephony/ril.h
+++ b/include/telephony/ril.h
@@ -599,6 +599,7 @@ typedef struct {
              * clir == 2 on "CLIR suppression" (allow CLI presentation)
              */
     RIL_UUS_Info *  uusInfo;    /* NULL or Pointer to User-User Signaling Information */
+    void* unknown;   /*needed for vendor ril */
 } RIL_Dial;
 
 typedef struct {


### PR DESCRIPTION
The used prebuild vendor ril expects an extra field in the RIL_DIAL struct. This field needs to be set to an valid address
otherwise rild will crash. Since the meaning of this extra reference is unkown it is initialized with null.

Change-Id: I37874b8f2c4fcc4654715253eed8677a5257d9ac